### PR TITLE
Update ttHJetToGG_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py

### DIFF
--- a/python/ThirteenTeV/Higgs/ttHJetToGG_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
+++ b/python/ThirteenTeV/Higgs/ttHJetToGG_M130_13TeV_amcatnloFXFX_madspin_pythia8_cff.py
@@ -30,7 +30,7 @@ pythia8aMCatNLOSettingsBlock,
   '23:mMin = 0.05',       # Solve problem with mZ cut
   '24:mMin = 0.05',       # Solve problem with mW cut
   '25:onMode = off', 
-  '25:onIfAny = 22 22',    # Decay only higgs to gamma gamma
+  '25:onIfMatch = 22 22',    # Decay only higgs to gamma gamma, note onIfMatch is used instead of onIfAny since otherwise H->Gamma Z, Z-> Gamma is also possible.
   ),
 parameterSets = cms.vstring('pythia8CommonSettings',
 'pythia8CUEP8M1Settings',


### PR DESCRIPTION
Fix decay of Higgs to Gamma Gamma.
Note onIfMatch is used instead of onIfAny since otherwise H->Gamma Z, Z-> Gamma is also possible.
